### PR TITLE
Implement sending and receiving files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ result
 .direnv/
 .pre-commit-config.yaml
 
+# IDE
+.idea/
+
 # Files and directories created by pub
 .dart_tool/
 .packages

--- a/lib/shell.dart
+++ b/lib/shell.dart
@@ -183,6 +183,11 @@ Future<void> shell() async {
           receivedRequests.addAll(data);
           console.writeLine("Received a send request from $peer".blue());
           prompt();
+        case "decline":
+          final request = message["data"];
+          final peer = PeerInfo.fromJson(request["peer"]);
+          console.writeLine("Request from $peer was declined.".red());
+          prompt();
       }
     } else {
       console.writeErrorLine(message);
@@ -244,15 +249,35 @@ Future<void> shell() async {
         return;
       }
 
-
-
       workerSendPort.send({
         "type": "accept",
         "data": {
           "hash": receivedRequests[requestID]["hash"],
           "peer": receivedRequests[requestID]["peer"].toJson(),
           "destination": args.length == 2 ? args[1] : "",
-        }
+        },
+      });
+      receivedRequests.remove(requestID);
+    },
+    "decline": (args) async {
+      if (args.length != 1) {
+        console.writeErrorLine('Usage: decline [request id]');
+        return;
+      }
+
+      final requestID = int.parse(args[0]);
+
+      if (!receivedRequests.containsKey(requestID)) {
+        console.writeErrorLine('Request ID $requestID not found.');
+        return;
+      }
+
+      workerSendPort.send({
+        "type": "decline",
+        "data": {
+          "hash": receivedRequests[requestID]["hash"],
+          "peer": receivedRequests[requestID]["peer"].toJson(),
+        },
       });
       receivedRequests.remove(requestID);
     },

--- a/lib/shell.dart
+++ b/lib/shell.dart
@@ -188,6 +188,23 @@ Future<void> shell() async {
           final peer = request["peer"];
           console.writeLine("Request from $peer was declined.".red());
           prompt();
+        case "fileReceived":
+          final filePath = message['data'];
+          console.writeLine("File received: $filePath".green());
+          prompt();
+        case "sendingFileError":
+          final peer = PeerInfo.fromJson(message['data']['peer']);
+          final error = message['data']['error'];
+          final file = message['data']['file'];
+          console.writeErrorLine(
+            "Error sending file $file to $peer: $error".red(),
+          );
+          prompt();
+        case "receivingFileError":
+          final file = message['data']['file'];
+          final error = message['data']['error'];
+          console.writeErrorLine("Error receiving file $file: $error".red());
+          prompt();
       }
     } else {
       console.writeErrorLine(message);

--- a/lib/shell.dart
+++ b/lib/shell.dart
@@ -112,7 +112,6 @@ String requests() {
   if (receivedRequests.isEmpty) {
     return "No requests yet 😥".bold();
   }
-  console.writeLine(receivedRequests);
 
   List<List<String>> rows = [
     ["ID", "Peer", "File", "Size", "Hash"],
@@ -122,7 +121,7 @@ String requests() {
     final request = receivedRequests[requestID];
     rows.add([
       requestID.toString(),
-      PeerInfo.fromJson(request["peer"]).toString(),
+      request["peer"].toString(),
       request["file"].split("/").last,
       request["size"].toString(),
       request["hash"].toString(),
@@ -175,8 +174,10 @@ Future<void> shell() async {
         case "request":
           final requestID = message["data"].keys.first;
           final request = message["data"][requestID];
-          final peer = PeerInfo.fromJson(request["peer"]);
-          receivedRequests.addAll(message["data"]);
+          final peer = discoveredPeers.firstWhere((p) => p.hostname == request["peer"]);
+          final data = message["data"];
+          data[requestID]["peer"] = peer;
+          receivedRequests.addAll(data);
           console.writeLine("Received a send request from $peer".blue());
           prompt();
       }

--- a/lib/shell.dart
+++ b/lib/shell.dart
@@ -252,7 +252,7 @@ Future<void> shell() async {
     },
     "requests": (args) async => console.writeLine(requests()),
     "accept": (args) async {
-      if (args.isEmpty || args.length > 2) {
+      if (args.isEmpty) {
         console.writeErrorLine(
           'Usage: accept [request id]... <destination path>',
         );
@@ -260,7 +260,10 @@ Future<void> shell() async {
       }
 
       final requestID = int.parse(args[0]);
-
+      String destination = "";
+      if (args.length > 1) {
+        destination = args.sublist(1).join(" ");
+      }
       if (!receivedRequests.containsKey(requestID)) {
         console.writeErrorLine('Request ID $requestID not found.');
         return;
@@ -271,7 +274,7 @@ Future<void> shell() async {
         "data": {
           "hash": receivedRequests[requestID]["hash"],
           "peer": receivedRequests[requestID]["peer"].toJson(),
-          "destination": args.length == 2 ? args[1] : "",
+          "destination": destination,
         },
       });
       receivedRequests.remove(requestID);

--- a/lib/shell.dart
+++ b/lib/shell.dart
@@ -185,7 +185,7 @@ Future<void> shell() async {
           prompt();
         case "decline":
           final request = message["data"];
-          final peer = PeerInfo.fromJson(request["peer"]);
+          final peer = request["peer"];
           console.writeLine("Request from $peer was declined.".red());
           prompt();
       }

--- a/lib/shell.dart
+++ b/lib/shell.dart
@@ -122,7 +122,7 @@ String requests() {
     rows.add([
       requestID.toString(),
       request["peer"].toString(),
-      request["file"].split("/").last,
+      request["file"].split(RegExp(r'[\\/]')).last,
       request["size"].toString(),
       request["hash"].toString(),
     ]);

--- a/lib/tuxshare.dart
+++ b/lib/tuxshare.dart
@@ -40,7 +40,7 @@ class TuxShare {
   /// optional callback functions
   void Function(PeerInfo peer)? onPeerDiscovered;
   void Function(PeerInfo peer)? onPeerForget;
-  void Function(PeerInfo peer)? onSendOffer;
+  void Function(Map<int, dynamic>)? onRequest;
 
   TuxShare(
     this._localHostname, {
@@ -134,7 +134,7 @@ class TuxShare {
         }
       } else if (map["msg"] == "sendOffer") {
         _requests[_requestCounter] = map["data"];
-        onSendOffer?.call(PeerInfo.fromJson(map["data"]["peer"]));
+        onRequest?.call({_requestCounter: map["data"]});
         _requestCounter++;
       }
     }
@@ -152,6 +152,7 @@ class TuxShare {
       "peer": peer,
       "file": file.path,
       "size": await file.length(),
+      "hash": hash,
     };
 
     _socket?.send(

--- a/lib/tuxshare.dart
+++ b/lib/tuxshare.dart
@@ -147,9 +147,9 @@ class TuxShare {
 
   /// Send a file to Peer
   Future<void> sendFile(PeerInfo peer, File file, {int port = 9696}) async {
-    int hash = Object.hash(_localHostname, file.path);
+    int hash = Object.hash(peer.hostname, file.path);
     _sendingTo[hash] = {
-      "peer": peer,
+      "peer": peer.hostname,
       "file": file.path,
       "size": await file.length(),
       "hash": hash,
@@ -161,7 +161,7 @@ class TuxShare {
           "msg": "TS_SEND_OFFER",
           "data": {
             ..._sendingTo[hash],
-            ...{"hash": hash},
+            ...{"peer": _localHostname},
           },
         }),
       ),

--- a/lib/tuxshare.dart
+++ b/lib/tuxshare.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 import "dart:io";
 
 import "package:tuxshare/peer_info.dart";
+import "package:tuxshare/shell.dart";
 
 /// TuxShare is a class that handles the discovery and data-handling of peers in the network
 class TuxShare {
@@ -54,6 +55,10 @@ class TuxShare {
        _responseMessage = responseMessage;
 
   Set<PeerInfo> get peers => _discoveredPeers;
+
+  PeerInfo getPeerFromHostname(String hostname) {
+    return discoveredPeers.firstWhere((peer) => peer.hostname == hostname);
+  }
 
   /// Starts listening for incoming datagrams
   Future<void> startListening() async {

--- a/lib/tuxshare.dart
+++ b/lib/tuxshare.dart
@@ -135,28 +135,27 @@ class TuxShare {
     _socket?.close();
   }
 
-  /// sendet eine Datei per TCP an einen Ziel-Peer
-  Future<void> sendFile({
-    required InternetAddress address,
-    required int port,
-    required String filePath,
+  /// Send a file to Peer
+  Future<void> sendFile(
+    InternetAddress address,
+    String filePath, {
+    int port = 9696,
   }) async {
     final file = File(filePath);
     if (!await file.exists()) {
-      throw FileSystemException("Datei existiert nicht", filePath);
+      throw FileSystemException("File does not exist", filePath);
     }
 
-    // TCP-Verbindung aufbauen
     final socket = await Socket.connect(
       address,
       port,
-    ).catchError((e) => throw SocketException("Verbindung fehlgeschlagen: $e"));
+    ).catchError((e) => throw SocketException("Connection failed: $e"));
 
     try {
-      await socket.addStream(file.openRead()); // Datei-Stream senden
-      await socket.flush(); // Puffer leeren
+      await socket.addStream(file.openRead());
+      await socket.flush();
     } finally {
-      await socket.close(); // immer sauber schließen
+      await socket.close();
     }
   }
 }

--- a/lib/tuxshare.dart
+++ b/lib/tuxshare.dart
@@ -132,7 +132,7 @@ class TuxShare {
           _discoveredPeers.add(peer); // New peer
           onPeerDiscovered?.call(peer);
         }
-      } else if (map["msg"] == "sendOffer") {
+      } else if (map["msg"] == "TS_SEND_OFFER") {
         _requests[_requestCounter] = map["data"];
         onRequest?.call({_requestCounter: map["data"]});
         _requestCounter++;
@@ -158,7 +158,7 @@ class TuxShare {
     _socket?.send(
       utf8.encode(
         jsonEncode({
-          "msg": "sendOffer",
+          "msg": "TS_SEND_OFFER",
           "data": {
             ..._sendingTo[hash],
             ...{"hash": hash},

--- a/lib/tuxshare.dart
+++ b/lib/tuxshare.dart
@@ -141,6 +141,8 @@ class TuxShare {
         _requests[_requestCounter] = map["data"];
         onRequest?.call({_requestCounter: map["data"]});
         _requestCounter++;
+      } else if (map["msg"] == "TS_ACCEPT_OFFER") {
+        // TODO
       }
     }
   }
@@ -185,5 +187,24 @@ class TuxShare {
     // } finally {
     //   await socket.close();
     // }
+  }
+
+  /// Send a file to Peer
+  Future<void> acceptFile(int fileHash, PeerInfo peer, String destinationFilePath) async {
+
+    print("cock");
+    _socket?.send(
+      utf8.encode(
+        jsonEncode({
+          "msg": "TS_ACCEPT_OFFER",
+          "data": {
+            "peer": _localHostname,
+            "hash": fileHash
+          },
+        }),
+      ),
+      peer.address,
+      _multicastPort,
+    );
   }
 }

--- a/lib/tuxshare.dart
+++ b/lib/tuxshare.dart
@@ -157,7 +157,7 @@ class TuxShare {
   }
 
   /// Send a file to Peer
-  Future<void> sendFile(PeerInfo peer, File file, {int port = 9696}) async {
+  Future<void> sendOffer(PeerInfo peer, File file, {int port = 9696}) async {
     int hash = Object.hash(peer.hostname, file.path);
     _sendingTo[hash] = {
       "peer": peer,

--- a/lib/tuxshare.dart
+++ b/lib/tuxshare.dart
@@ -42,7 +42,7 @@ class TuxShare {
   void Function(PeerInfo peer)? onPeerDiscovered;
   void Function(PeerInfo peer)? onPeerForget;
   void Function(Map<int, dynamic>)? onRequest;
-  void Function(Map<int, dynamic>)? onRequestDecline;
+  void Function(Map<String, dynamic>)? onRequestDecline;
 
   TuxShare(
     this._localHostname, {
@@ -146,7 +146,7 @@ class TuxShare {
         // TODO
       } else if (map["msg"] == "TS_DECLINE_OFFER") {
         final request = _sendingTo.remove(map["data"]["hash"]);
-        onPeerDiscovered?.call(request);
+        onRequestDecline?.call(request);
       }
     }
   }

--- a/lib/tuxshare.dart
+++ b/lib/tuxshare.dart
@@ -190,17 +190,17 @@ class TuxShare {
   }
 
   /// Send a file to Peer
-  Future<void> acceptFile(int fileHash, PeerInfo peer, String destinationFilePath) async {
-
+  Future<void> acceptFile(
+    int fileHash,
+    PeerInfo peer,
+    String destinationFilePath,
+  ) async {
     print("cock");
     _socket?.send(
       utf8.encode(
         jsonEncode({
           "msg": "TS_ACCEPT_OFFER",
-          "data": {
-            "peer": _localHostname,
-            "hash": fileHash
-          },
+          "data": {"peer": _localHostname, "hash": fileHash},
         }),
       ),
       peer.address,

--- a/lib/tuxshare.dart
+++ b/lib/tuxshare.dart
@@ -134,4 +134,29 @@ class TuxShare {
     _discoveryTimer?.cancel();
     _socket?.close();
   }
+
+  Future<void> sendFile({
+    required InternetAddress address,
+    required int port,
+    required String filePath,
+  }) async {
+    final file = File(filePath);
+    if (!await file.exists()) {
+      throw FileSystemException("Datei existiert nicht", filePath);
+    }
+
+    Socket socket;
+    try {
+      socket = await Socket.connect(address, port);
+    } catch (e) {
+      throw SocketException("Verbindung zu $address:$port fehlgeschlagen: $e");
+    }
+
+    try {
+      await socket.addStream(file.openRead());
+      await socket.flush();
+    } finally {
+      await socket.close();
+    }
+  }
 }

--- a/lib/tuxshare.dart
+++ b/lib/tuxshare.dart
@@ -135,6 +135,7 @@ class TuxShare {
     _socket?.close();
   }
 
+  /// sendet eine Datei per TCP an einen Ziel-Peer
   Future<void> sendFile({
     required InternetAddress address,
     required int port,
@@ -145,18 +146,17 @@ class TuxShare {
       throw FileSystemException("Datei existiert nicht", filePath);
     }
 
-    Socket socket;
-    try {
-      socket = await Socket.connect(address, port);
-    } catch (e) {
-      throw SocketException("Verbindung zu $address:$port fehlgeschlagen: $e");
-    }
+    // TCP-Verbindung aufbauen
+    final socket = await Socket.connect(
+      address,
+      port,
+    ).catchError((e) => throw SocketException("Verbindung fehlgeschlagen: $e"));
 
     try {
-      await socket.addStream(file.openRead());
-      await socket.flush();
+      await socket.addStream(file.openRead()); // Datei-Stream senden
+      await socket.flush(); // Puffer leeren
     } finally {
-      await socket.close();
+      await socket.close(); // immer sauber schließen
     }
   }
 }

--- a/lib/tuxshare_worker.dart
+++ b/lib/tuxshare_worker.dart
@@ -36,6 +36,12 @@ void backendMain(SendPort sendPort) async {
           PeerInfo.fromJson(msg["data"]["peer"]),
           msg["data"]["file"],
         );
+      } else if (msg["type"] == "accept") {
+        tuxshare.acceptFile(
+          msg["data"]["hash"],
+          PeerInfo.fromJson(msg["data"]["peer"]),
+          msg["data"]["destination"],
+        );
       }
     }
   }

--- a/lib/tuxshare_worker.dart
+++ b/lib/tuxshare_worker.dart
@@ -20,8 +20,8 @@ void backendMain(SendPort sendPort) async {
     sendPort.send({'type': 'peerForget', 'data': peer.toJson()});
   };
 
-  tuxshare.onSendOffer = (peer) {
-    sendPort.send({'type': 'sendOffer', 'data': peer.toJson()});
+  tuxshare.onRequest = (request) {
+    sendPort.send({'type': 'request', 'data': request});
   };
 
   await for (var msg in receivePort) {

--- a/lib/tuxshare_worker.dart
+++ b/lib/tuxshare_worker.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:isolate';
+
 import 'package:tuxshare/peer_info.dart';
 import 'package:tuxshare/tuxshare.dart';
 
@@ -24,6 +25,10 @@ void backendMain(SendPort sendPort) async {
     sendPort.send({'type': 'request', 'data': request});
   };
 
+  tuxshare.onRequestDecline = (request) {
+    sendPort.send({'type': 'decline', 'data': request});
+  };
+
   await for (var msg in receivePort) {
     if (msg is Map<String, dynamic>) {
       if (msg["type"] == "discover") {
@@ -41,6 +46,11 @@ void backendMain(SendPort sendPort) async {
           msg["data"]["hash"],
           PeerInfo.fromJson(msg["data"]["peer"]),
           msg["data"]["destination"],
+        );
+      } else if (msg["type"] == "decline") {
+        tuxshare.declineFile(
+          msg["data"]["hash"],
+          PeerInfo.fromJson(msg["data"]["peer"]),
         );
       }
     }

--- a/lib/tuxshare_worker.dart
+++ b/lib/tuxshare_worker.dart
@@ -37,7 +37,7 @@ void backendMain(SendPort sendPort) async {
         tuxshare.close();
         break;
       } else if (msg["type"] == "send") {
-        tuxshare.sendFile(
+        tuxshare.sendOffer(
           PeerInfo.fromJson(msg["data"]["peer"]),
           msg["data"]["file"],
         );

--- a/lib/tuxshare_worker.dart
+++ b/lib/tuxshare_worker.dart
@@ -29,6 +29,29 @@ void backendMain(SendPort sendPort) async {
     sendPort.send({'type': 'decline', 'data': request});
   };
 
+  tuxshare.onFileReceived = (filePath) {
+    sendPort.send({'type': 'fileReceived', 'data': filePath});
+  };
+
+  tuxshare.onSendingFileError = (peer, file, error) {
+    sendPort.send({
+      'type': 'sendingFileError',
+      'data': {'peer': peer.toJson(), 'file': file, 'error': error.toString()},
+    });
+  };
+
+  tuxshare.onReceivingFileError = (file, error) {
+    sendPort.send({
+      'type': 'receivingFileError',
+      'data': {'file': file, 'error': error.toString()},
+    });
+  };
+
+
+  void Function(String)? onFileReceived;
+  void Function(PeerInfo, String)? onSendingFileError;
+  void Function(String)? onReceivingFileError;
+
   await for (var msg in receivePort) {
     if (msg is Map<String, dynamic>) {
       if (msg["type"] == "discover") {

--- a/lib/tuxshare_worker.dart
+++ b/lib/tuxshare_worker.dart
@@ -47,11 +47,6 @@ void backendMain(SendPort sendPort) async {
     });
   };
 
-
-  void Function(String)? onFileReceived;
-  void Function(PeerInfo, String)? onSendingFileError;
-  void Function(String)? onReceivingFileError;
-
   await for (var msg in receivePort) {
     if (msg is Map<String, dynamic>) {
       if (msg["type"] == "discover") {


### PR DESCRIPTION
- **send: add logic for sending data via TCP-socket**
- **send: documentation for sendFile function**
- **send: use English comments and exceptions and set default port**
- **tuxshare: implement send offer logic**
- **shell: implement requests command**
- **tuxshare: rename send offers to TS_SEND_OFFER**
- **.gitignore: add .idea**
- **send: send hostname instead of peer object in offer**
- **shell: add windows path support to requests output**
- **tuxshare: add function to get a peer object from a hostname**
- **send: implement accept logic**
- **treewide: fmt**
- **send: implement decline logic**
- **send: change peer datatype in decline logic**
- **send: rename sendFile to sendOffer to better reflect the functionality**
- **send: implement send and receive files**
- **send: allow paths with whitespaces in accept**
- **tuxshare_worker: remove useless callback functions**
